### PR TITLE
Filter jobs by reputable application sources

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,6 +35,10 @@ on:
         description: "Schedule Types (JSON list or comma-separated)"
         required: false
         type: string
+      trusted_domains:
+        description: "Trusted Domains (JSON list or comma-separated)"
+        required: false
+        type: string
       google_domain:
         description: "Google Domain"
         required: false
@@ -89,6 +93,7 @@ jobs:
           BLACKLIST_COMPANIES: ${{ inputs.blacklist_companies || vars.BLACKLIST_COMPANIES }}
           EXCLUDE_KEYWORDS: ${{ inputs.exclude_keywords || vars.EXCLUDE_KEYWORDS }}
           SCHEDULE_TYPES: ${{ inputs.schedule_types || vars.SCHEDULE_TYPES }}
+          TRUSTED_DOMAINS: ${{ inputs.trusted_domains || vars.TRUSTED_DOMAINS }}
           GOOGLE_DOMAIN: ${{ inputs.google_domain || vars.GOOGLE_DOMAIN }}
           GL: ${{ inputs.gl || vars.GL }}
           HL: ${{ inputs.hl || vars.HL }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can configure the job search parameters using environment variables. This wo
 | `BLACKLIST_COMPANIES` | List of companies to exclude (JSON list or comma-separated).                                                          | `[]`                       |
 | `EXCLUDE_KEYWORDS`    | List of keywords to exclude from job titles (JSON list or comma-separated).                                           | `[]`                       |
 | `SCHEDULE_TYPES`      | List of allowed schedule types (JSON list or comma-separated). e.g. `["Full-time", "Part-time"]`                      | `["Full-time"]`            |
+| `TRUSTED_DOMAINS`     | List of trusted domains for application sources (JSON list or comma-separated).                                       | `["linkedin", "glassdoor", "indeed"]` |
 | `GOOGLE_DOMAIN`       | The Google domain to use.                                                                                             | `google.ca`                |
 | `GL`                  | Country code for search results.                                                                                      | `ca`                       |
 | `HL`                  | Language code for search results.                                                                                     | `en`                       |

--- a/src/config.py
+++ b/src/config.py
@@ -69,6 +69,14 @@ class Config:
             # Default to Full-time if not specified
             self.schedule_types = ["full-time"]
 
+        # Trusted Domains for Application Sources
+        trusted_domains_str = os.getenv("TRUSTED_DOMAINS")
+        if trusted_domains_str:
+            self.trusted_domains = self._parse_list(trusted_domains_str)
+        else:
+            # Default trusted domains
+            self.trusted_domains = ["linkedin", "glassdoor", "indeed", "ziprecruiter", "simplyhired"]
+
     def _parse_list(self, env_str):
         """Parses a JSON list string or comma-separated string into a list."""
         if not env_str:

--- a/src/job_filter.py
+++ b/src/job_filter.py
@@ -5,10 +5,11 @@ class JobFilter:
         self.blacklist_companies = [c.lower() for c in config.blacklist_companies]
         self.exclude_keywords = [k.lower() for k in config.exclude_keywords]
         self.schedule_types = [s.lower() for s in config.schedule_types]
+        self.trusted_domains = [d.lower() for d in config.trusted_domains]
 
     def is_valid(self, job):
         """
-        Checks if a job is valid based on blacklist, keywords, and schedule type.
+        Checks if a job is valid based on blacklist, keywords, schedule type, and application sources.
         Returns (bool, reason).
         """
         title = job.get('title', '').lower()
@@ -36,4 +37,40 @@ class JobFilter:
             if not is_allowed:
                 return False, f"Invalid schedule type: {job.get('detected_extensions', {}).get('schedule_type')}"
 
+        # Check application sources
+        has_source, source_reason = self.has_reputable_source(job)
+        if not has_source:
+            return False, source_reason
+
         return True, None
+
+    def has_reputable_source(self, job):
+        """
+        Checks if the job has at least one reputable application source.
+        Returns (bool, reason).
+        """
+        apply_options = job.get('apply_options', [])
+        if not apply_options:
+            # If there are no apply options, we can't determine if it's reputable or not.
+            # Assuming we want to filter these out as "low quality" or "not actionable".
+            return False, "No application options found"
+
+        company_name = job.get('company_name', '').lower()
+        # Normalize company name for URL check (remove spaces, punctuation could be tricky but let's start simple)
+        normalized_company = ''.join(e for e in company_name if e.isalnum())
+        
+        for option in apply_options:
+            link = option.get('link', '').lower()
+            title = option.get('title', '').lower()
+            
+            # Check trusted domains
+            for domain in self.trusted_domains:
+                if domain in link or domain in title:
+                    return True, None
+            
+            # Check direct company page
+            # Heuristic: if normalized company name is in the link
+            if normalized_company and normalized_company in link:
+                return True, None
+                    
+        return False, "No reputable application source found"

--- a/src/main.py
+++ b/src/main.py
@@ -103,7 +103,7 @@ def main():
         history.add_job(job)
     
     logging.info(f"Skipped {skipped_history} jobs due to history (already seen).")
-    logging.info(f"Skipped {skipped_filter} jobs due to blacklist/keywords/schedule type.")
+    logging.info(f"Skipped {skipped_filter} jobs due to filters (blacklist/keywords/schedule/sources).")
     logging.info(f"Skipped {skipped_salary} jobs due to low salary.")
     logging.info(f"Skipped {skipped_date} jobs due to age.")
     logging.info(f"Net new jobs after history, salary, and date check: {len(new_jobs)}")

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -8,6 +8,7 @@ def mock_config():
     config.blacklist_companies = ["bad company", "spam corp"]
     config.exclude_keywords = ["senior", "intern"]
     config.schedule_types = ["full-time"]
+    config.trusted_domains = ["linkedin", "glassdoor", "indeed"]
     return config
 
 def test_job_filter_valid_job(mock_config):
@@ -15,7 +16,8 @@ def test_job_filter_valid_job(mock_config):
     job_filter = JobFilter(mock_config)
     job = {
         "title": "Software Engineer",
-        "company_name": "Good Company"
+        "company_name": "Good Company",
+        "apply_options": [{"title": "LinkedIn", "link": "https://linkedin.com/jobs/..."}]
     }
     is_valid, reason = job_filter.is_valid(job)
     assert is_valid is True

--- a/tests/test_job_filter_schedule.py
+++ b/tests/test_job_filter_schedule.py
@@ -8,6 +8,7 @@ def mock_config():
     config.blacklist_companies = ["Bad Corp"]
     config.exclude_keywords = ["Senior"]
     config.schedule_types = ["Full-time"]
+    config.trusted_domains = ["linkedin", "glassdoor", "indeed"]
     return config
 
 def test_job_filter_schedule_type_full_time(mock_config):
@@ -16,7 +17,8 @@ def test_job_filter_schedule_type_full_time(mock_config):
     job = {
         "title": "Developer",
         "company_name": "Good Corp",
-        "detected_extensions": {"schedule_type": "Full-time"}
+        "detected_extensions": {"schedule_type": "Full-time"},
+        "apply_options": [{"title": "LinkedIn", "link": "https://linkedin.com/jobs/..."}]
     }
     is_valid, reason = job_filter.is_valid(job)
     assert is_valid is True
@@ -28,7 +30,8 @@ def test_job_filter_schedule_type_missing(mock_config):
     job = {
         "title": "Developer",
         "company_name": "Good Corp",
-        "detected_extensions": {}
+        "detected_extensions": {},
+        "apply_options": [{"title": "LinkedIn", "link": "https://linkedin.com/jobs/..."}]
     }
     is_valid, reason = job_filter.is_valid(job)
     assert is_valid is True
@@ -41,6 +44,7 @@ def test_job_filter_schedule_type_none(mock_config):
         "title": "Developer",
         "company_name": "Good Corp",
         # No detected_extensions key at all
+        "apply_options": [{"title": "LinkedIn", "link": "https://linkedin.com/jobs/..."}]
     }
     is_valid, reason = job_filter.is_valid(job)
     assert is_valid is True
@@ -81,7 +85,8 @@ def test_job_filter_schedule_type_custom_config(mock_config):
     job_pt = {
         "title": "Developer",
         "company_name": "Good Corp",
-        "detected_extensions": {"schedule_type": "Part-time"}
+        "detected_extensions": {"schedule_type": "Part-time"},
+        "apply_options": [{"title": "LinkedIn", "link": "https://linkedin.com/jobs/..."}]
     }
     is_valid, reason = job_filter.is_valid(job_pt)
     assert is_valid is True

--- a/tests/test_job_filter_sources.py
+++ b/tests/test_job_filter_sources.py
@@ -1,0 +1,137 @@
+import pytest
+from unittest.mock import Mock
+from job_filter import JobFilter
+
+@pytest.fixture
+def mock_config():
+    config = Mock()
+    config.blacklist_companies = []
+    config.exclude_keywords = []
+    config.schedule_types = ["full-time"]
+    config.trusted_domains = ["linkedin", "glassdoor", "indeed", "ziprecruiter", "simplyhired"]
+    return config
+
+def test_job_filter_source_linkedin(mock_config):
+    """Test that a job with a LinkedIn source is accepted."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": [
+            {"title": "LinkedIn", "link": "https://www.linkedin.com/jobs/view/..."}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None
+
+def test_job_filter_source_glassdoor(mock_config):
+    """Test that a job with a Glassdoor source is accepted."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": [
+            {"title": "Glassdoor", "link": "https://www.glassdoor.com/job/..."}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None
+
+def test_job_filter_source_indeed(mock_config):
+    """Test that a job with an Indeed source is accepted."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": [
+            {"title": "Indeed", "link": "https://ca.indeed.com/viewjob?..."}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None
+
+def test_job_filter_source_company_direct(mock_config):
+    """Test that a job with a direct company link is accepted."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Acme Corp",
+        "apply_options": [
+            {"title": "Apply on Acme Corp", "link": "https://careers.acmecorp.com/job/123"}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None
+
+def test_job_filter_source_generic_aggregator(mock_config):
+    """Test that a job with only generic aggregators is rejected."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": [
+            {"title": "Techjobs.ca", "link": "https://www.techjobs.ca/job/..."},
+            {"title": "BeBee CA", "link": "https://ca.bebee.com/job/..."}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is False
+    assert reason == "No reputable application source found"
+
+def test_job_filter_source_no_options(mock_config):
+    """Test that a job with no apply options is rejected."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": []
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is False
+    assert reason == "No application options found"
+
+def test_job_filter_source_company_name_match_complex(mock_config):
+    """Test company name matching with spaces/normalization."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "The Best Company",
+        "apply_options": [
+            {"title": "Apply", "link": "https://thebestcompany.com/careers"}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None
+
+def test_job_filter_source_ziprecruiter(mock_config):
+    """Test that a job with a ZipRecruiter source is accepted."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": [
+            {"title": "ZipRecruiter", "link": "https://www.ziprecruiter.com/job/..."}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None
+
+def test_job_filter_source_simplyhired(mock_config):
+    """Test that a job with a SimplyHired source is accepted."""
+    job_filter = JobFilter(mock_config)
+    job = {
+        "title": "Software Engineer",
+        "company_name": "Tech Corp",
+        "apply_options": [
+            {"title": "SimplyHired", "link": "https://www.simplyhired.com/job/..."}
+        ]
+    }
+    is_valid, reason = job_filter.is_valid(job)
+    assert is_valid is True
+    assert reason is None


### PR DESCRIPTION
## Summary of Changes
Implemented a validation logic to filter out job postings that lack reputable application sources. This ensures that only high-quality listings with direct application links (e.g., LinkedIn, Glassdoor, Indeed, ZipRecruiter, SimplyHired, or direct company pages) are processed, while generic aggregators are discarded.

* **Story/Issue Fixed:**
    * Fixes #49

---

## Key Implementation Details

* **Database/Model Changes?** No
* **New Dependencies?** No
* **Key Files Changed:**
    * `src/config.py`: Added `TRUSTED_DOMAINS` configuration with defaults.
    * `src/job_filter.py`: Implemented `has_reputable_source` logic to validate `apply_options`.
    * `src/main.py`: Updated logging to reflect jobs skipped due to source validation.
    * `.github/workflows/workflow.yml`: Added `TRUSTED_DOMAINS` input and environment variable support.
    * `README.md`: Documented the new `TRUSTED_DOMAINS` configuration.
    * `tests/test_job_filter_sources.py`: Added comprehensive tests for source validation.

---

## Acceptance Criteria Check

* [x] All Acceptance Criteria from the associated issue have been verified.

---

## Testing Performed

* Tested the feature locally:
    * **Steps to Verify:**
        1. Ran the full test suite using `pytest`.
        2. Verified that new tests in `tests/test_job_filter_sources.py` cover various scenarios (trusted domains, company direct links, generic aggregators, empty options).